### PR TITLE
Update activity type filter

### DIFF
--- a/src/DataProvider/Anplan/ActivityDataProvider.php
+++ b/src/DataProvider/Anplan/ActivityDataProvider.php
@@ -71,13 +71,12 @@ class ActivityDataProvider implements
      */
     public function getCollection(string $resourceClass, string $operationName = null, $context = null)
     {
-        $showInvisible = $context['filters']['visible'] ?? null === 'false' && $this->isAllowedToViewHidden();
         if ($resourceClass !== Activity::class) {
             throw new ResourceClassNotSupportedException('Invalid resource ' . $resourceClass);
         }
 
         $queryBuilder = $this->activityRepository->createQueryBuilder('t');
-        if (!$showInvisible) {
+        if (!$this->isAllowedToViewHidden()) {
             $queryBuilder->where('t.visible = 1');
         }
 

--- a/src/Entity/Anplan/Activity.php
+++ b/src/Entity/Anplan/Activity.php
@@ -33,7 +33,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
  * @ApiFilter(NumericFilter::class, properties={"festivalId"})
  * @ApiFilter(
  *      BooleanFilter::class,
- *      properties={"activityType.visible"}
+ *      properties={"visible", "activityType.visible"}
  *  )
  */
 class Activity

--- a/src/Entity/Anplan/Activity.php
+++ b/src/Entity/Anplan/Activity.php
@@ -33,7 +33,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
  * @ApiFilter(NumericFilter::class, properties={"festivalId"})
  * @ApiFilter(
  *      BooleanFilter::class,
- *      properties={"activityType.visible", "activityType.visible"}
+ *      properties={"activityType.visible"}
  *  )
  */
 class Activity

--- a/src/Entity/Anplan/Activity.php
+++ b/src/Entity/Anplan/Activity.php
@@ -33,7 +33,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
  * @ApiFilter(NumericFilter::class, properties={"festivalId"})
  * @ApiFilter(
  *      BooleanFilter::class,
- *      properties={"visible", "activityType.visible"}
+ *      properties={"activityType.visible", "activityType.visible"}
  *  )
  */
 class Activity


### PR DESCRIPTION
visible was used in the provider AND as activity type filter.
This way @beverloo can use visible=false to get around the visible filter in the provider, and activityType.visible can be used freely.