### PR TITLE
Refactor timezone adjustment for DateTime

### DIFF
--- a/src/Entity/Anplan/Timeslot.php
+++ b/src/Entity/Anplan/Timeslot.php
@@ -120,7 +120,14 @@ class Timeslot
     private function forceTimezone(DateTimeInterface $date): string
     {
         $local = new \DateTimeZone('Europe/Amsterdam');
-        $timezonedDate = DateTime::createFromFormat('U', (string) $date->getTimestamp(), $local);
+        $utc = new \DateTimeZone('GMT');
+
+        $dateUtc = new \DateTime("@{$date->getTimestamp()}", $utc);
+        $offset = $local->getOffset($dateUtc);
+
+        $adjustedTimestamp = $date->getTimestamp() - $offset;
+
+        $timezonedDate = \DateTime::createFromFormat('U', (string) $adjustedTimestamp, $utc);
         if ($timezonedDate === false) {
             throw new \Exception('Could not create DateTime from timestamp');
         }


### PR DESCRIPTION
The commit contains an essential update on how date and time is handled within the 'Timeslot' entity. It now correctly applies a timezone offset when converting a DateTimeInterface instance into a DateTime object. This ensures that conversions between Timezones are handled properly, improving the accuracy of time-based computations in the application.

Fixes #51 