### PR TITLE
Activity's `pac_max_visitors` type is an int, not a bool

### DIFF
--- a/src/Entity/Anplan/Activity.php
+++ b/src/Entity/Anplan/Activity.php
@@ -95,7 +95,7 @@ class Activity
     public bool $spellChecked;
 
     /**
-     * @ORM\Column(name="pac_max_visitors", type="boolean")
+     * @ORM\Column(name="pac_max_visitors", type="integer")
      * @Groups({"read"})
      */
     public ?int $maxVisitors;


### PR DESCRIPTION
It currently populates the field with either `1` or `null`, but that should be any number or `null`.